### PR TITLE
Feature/correlation id logging

### DIFF
--- a/correlationIdMiddleware/correlationIdMiddleware/CorrelationContext.cs
+++ b/correlationIdMiddleware/correlationIdMiddleware/CorrelationContext.cs
@@ -4,14 +4,14 @@
 public class CorrelationContext : ICorrelationContext
 {
     /// <inheritdoc />
-    public string? CorrelationId { get; private set; }
+    public Guid CorrelationId { get; private set; }
 
     /// <inheritdoc />
-    public void SetContext(string correlationId)
+    public void SetContext(Guid correlationId)
     {
-        if (string.IsNullOrWhiteSpace(correlationId))
+        if (correlationId == Guid.Empty)
         {
-            throw new ArgumentNullException(nameof(correlationId));
+            throw new ArgumentException("Guid cannot be empty", nameof(correlationId));
         }
         this.CorrelationId = correlationId;
     }

--- a/correlationIdMiddleware/correlationIdMiddleware/CorrelationContext.cs
+++ b/correlationIdMiddleware/correlationIdMiddleware/CorrelationContext.cs
@@ -1,14 +1,18 @@
-﻿using Ardalis.GuardClauses;
+﻿namespace Dfe.Academisation.CorrelationIdMiddleware;
 
-namespace Dfe.Academisation.CorrelationIdMiddleware;
-
-public record CorrelationContext() : ICorrelationContext
+/// <inheritdoc />
+public class CorrelationContext : ICorrelationContext
 {
+    /// <inheritdoc />
     public string? CorrelationId { get; private set; }
+
+    /// <inheritdoc />
     public void SetContext(string correlationId)
     {
-        this.CorrelationId = Guard.Against.NullOrWhiteSpace(correlationId);
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            throw new ArgumentNullException(nameof(correlationId));
+        }
+        this.CorrelationId = correlationId;
     }
-
-    public string HeaderKey { get => "x-correlation-id"; }
 }

--- a/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
+++ b/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
@@ -26,7 +26,6 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     </ItemGroup>
 

--- a/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
+++ b/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
@@ -13,7 +13,7 @@
         <PackageTags>dfe;academisation;correlation;</PackageTags>
         <UserSecretsId>4ac4e7ef-aaff-48a4-9e4d-44371c231191</UserSecretsId>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>2.0.0</Version>
+        <Version>2.0.0-beta1</Version>
         <Authors>DFE-Digital</Authors>
     </PropertyGroup>
 

--- a/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
+++ b/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
@@ -13,7 +13,7 @@
         <PackageTags>dfe;academisation;correlation;</PackageTags>
         <UserSecretsId>4ac4e7ef-aaff-48a4-9e4d-44371c231191</UserSecretsId>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>2.0.0-beta1</Version>
+        <Version>2.0.0</Version>
         <Authors>DFE-Digital</Authors>
     </PropertyGroup>
 

--- a/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
+++ b/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
@@ -13,7 +13,7 @@
         <PackageTags>dfe;academisation;correlation;</PackageTags>
         <UserSecretsId>4ac4e7ef-aaff-48a4-9e4d-44371c231191</UserSecretsId>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.0</Version>
+        <Version>2.0.0</Version>
         <Authors>DFE-Digital</Authors>
     </PropertyGroup>
 
@@ -25,7 +25,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />

--- a/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
+++ b/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     </ItemGroup>
 
 </Project>

--- a/correlationIdMiddleware/correlationIdMiddleware/ICorrelationContext.cs
+++ b/correlationIdMiddleware/correlationIdMiddleware/ICorrelationContext.cs
@@ -1,8 +1,19 @@
 ﻿namespace Dfe.Academisation.CorrelationIdMiddleware;
 
+/// <summary>
+/// Provides access to the current correlation id. You should register this as a scoped / per web request
+/// dependency in your IoC/DI container.
+/// </summary>
 public interface ICorrelationContext
 {
+    /// <summary>
+    /// Returns the current correlation id if it has been set
+    /// </summary>
     public string? CorrelationId { get; }
+    
+    /// <summary>
+    /// Used by the middleware to store the current correlation id. Do not call this method yourself.
+    /// </summary>
+    /// <param name="correlationId"></param>
     public void SetContext(string correlationId);
-    public string HeaderKey { get; }
 }

--- a/correlationIdMiddleware/correlationIdMiddleware/ICorrelationContext.cs
+++ b/correlationIdMiddleware/correlationIdMiddleware/ICorrelationContext.cs
@@ -9,11 +9,11 @@ public interface ICorrelationContext
     /// <summary>
     /// Returns the current correlation id if it has been set
     /// </summary>
-    public string? CorrelationId { get; }
+    public Guid CorrelationId { get; }
     
     /// <summary>
     /// Used by the middleware to store the current correlation id. Do not call this method yourself.
     /// </summary>
     /// <param name="correlationId"></param>
-    public void SetContext(string correlationId);
+    public void SetContext(Guid correlationId);
 }

--- a/correlationIdMiddleware/correlationIdMiddleware/Keys.cs
+++ b/correlationIdMiddleware/correlationIdMiddleware/Keys.cs
@@ -9,5 +9,5 @@ public class Keys
     /// The header key use to detect incoming correlation ids, and to send them in responses.
     /// Use this key if you are making subsequent requests so that correlation flows between services
     /// </summary>
-    public const string HeaderKey = "x-correlation-id";
+    public const string HeaderKey = "x-correlationId";
 }

--- a/correlationIdMiddleware/correlationIdMiddleware/Keys.cs
+++ b/correlationIdMiddleware/correlationIdMiddleware/Keys.cs
@@ -1,0 +1,13 @@
+﻿namespace Dfe.Academisation.CorrelationIdMiddleware;
+/// <summary>
+/// The keys used by the correlation id middleware.
+/// </summary>
+
+public class Keys
+{
+    /// <summary>
+    /// The header key use to detect incoming correlation ids, and to send them in responses.
+    /// Use this key if you are making subsequent requests so that correlation flows between services
+    /// </summary>
+    public const string HeaderKey = "x-correlation-id";
+}

--- a/correlationIdMiddleware/correlationIdMiddleware/README.md
+++ b/correlationIdMiddleware/correlationIdMiddleware/README.md
@@ -2,6 +2,50 @@
 
 ## What does this do ?
 
+This package contains middleware that you can register in your AspNet application to enable detection of `x-correlationId` request headers that can then be propagated and use in logging, further requests, and responses.
+
 ## Why does it do it ?
 
+CorrelationIds that are passed between services and recorded in all logs help to dramatically reduce the complexity involved in debugging applications, particularly where multiple services are involved.
+
 ## How to use it 
+
+* Reference the Nuget package.
+
+* In your application start-up, register the correlation context as a scoped dependency. For example
+`services.AddScoped<ICorrelationContext, CorrelationContext>();`
+
+* Add the CorrelationId middleware to your AspNet middleware pipeline. You should add this as early as possible so that correlationIds can be logged.
+`app.UseMiddleware<CorrelationIdMiddleware>();`
+
+* Anywhere that you need access to the current correlation id, inject `ICorrelationContext` and access the current context using the `CorrelationId` property. It will return a `string?` that you can use in subsequent requests or wherever you need it.
+
+---
+
+## Default AspNet Logger
+The middleware will add the current correlation id as scoped data before calling the next middleware in the AspNet middleware pipeline.
+If you are using the default AspNet logger, to see this in your log output you need to enable scopes in the output.
+One simple way of doing this is to use the console output by adding the following to your logger configuration.
+Alternatively use something like Seq to view logs locally.
+
+```json
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Information",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    },
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "IncludeScopes": "true"
+      }
+    }
+  },
+```
+
+## Not using the default AspNet Logger ?
+The middleware will push an `x-correlationId` scope property onto the default Microsoft logging implementation.
+
+If you are using another logger, create a middleware and register it as the next one in the pipeline after the `CorrelationIdMiddleware`. Inject the `ICorrelationContext` into your middleware and use the `ICorrelationContext.CorrelationId` property to access the correlationId value and include it in your own logs. For example Serilog.


### PR DESCRIPTION
**What is the change?**
Enhancement to the correlation id middleware to push correlation id into the scope of aspnet logging

**Why do we need the change?**
correlation id needs to flow through requests

** Is this a breaking change ?**
yes because support has been restricted to guids only