### PR TITLE
Added check for incoming empty correlation id

### DIFF
--- a/correlationIdMiddleware/correlationIdMiddleware/CorrelationIdMiddleware.cs
+++ b/correlationIdMiddleware/correlationIdMiddleware/CorrelationIdMiddleware.cs
@@ -1,6 +1,8 @@
 ﻿namespace Dfe.Academisation.CorrelationIdMiddleware;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
 
 /// <summary>
 /// Middleware that checks incoming requests for a correlation and causation id header. If not found then default values will be created.
@@ -43,6 +45,21 @@ public class CorrelationIdMiddleware
             thisCorrelationId = Guid.NewGuid();
             _logger.LogWarning("CorrelationIdMiddleware:Invoke - x-correlationId not detected in request headers. Generated a new one: {correlationId}", thisCorrelationId);
         }
+
+        if (thisCorrelationId == Guid.Empty)
+        {
+            var result = new
+            {
+                StatusCode = (int)HttpStatusCode.BadRequest,
+                Message = $"Bad Request. {Keys.HeaderKey} header cannot be an empty GUID"
+            };
+
+
+            httpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+            httpContext.Response.ContentType = "text/json";
+            return httpContext.Response.WriteAsync(result.ToString());
+        }
+
 
         httpContext.Request.Headers[Keys.HeaderKey] = thisCorrelationId.ToString();
 

--- a/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
+++ b/correlationIdMiddleware/correlationIdMiddleware/Dfe.Academisation.CorrelationIdMiddleware.csproj
@@ -13,7 +13,7 @@
         <PackageTags>dfe;academisation;correlation;</PackageTags>
         <UserSecretsId>4ac4e7ef-aaff-48a4-9e4d-44371c231191</UserSecretsId>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>2.0.1</Version>
+        <Version>2.0.2</Version>
         <Authors>DFE-Digital</Authors>
     </PropertyGroup>
 

--- a/correlationIdMiddleware/correlationIdMiddleware/ReleaseNotes.md
+++ b/correlationIdMiddleware/correlationIdMiddleware/ReleaseNotes.md
@@ -1,3 +1,9 @@
+# 2.0.2
+Fixed passing in an empty GUID in the x-correlationId header causing an exception. Now if an empty GUID is detected a bad request will be returned.
+If an empty guid is returned, the content of the response returned (along with the 400 status code) will be 
+
+`{ StatusCode = 400, Message = Bad Request. x-correlationId header cannot be an empty GUID }`
+
 # 2.0.1
 Fix to the log output so that `x-correlationId [guid]` is now `x-correlationId: [guid]
 


### PR DESCRIPTION
Added a check for an incoming corellation id header being an empty guid, if detected then a bad request will be returned along with an appropriate message